### PR TITLE
inline declarations __print__::mutex_ and __print__ print

### DIFF
--- a/include/ptc/print.hpp
+++ b/include/ptc/print.hpp
@@ -336,10 +336,10 @@ namespace ptc
   //====================================================
 
   // __print__::mutex_ definiton
-  std::mutex __print__::mutex_;
+  inline std::mutex __print__::mutex_;
 
   // print function initialization
-  __print__ print;
+  inline __print__ print;
  } // end of namespace ptc
 
 #endif


### PR DESCRIPTION
Hello! I was testing the header in a little project and found that when I include "ptc\print.hpp" in multiple files I get a multiple definitions error. See #5 for more details. Simply solved by inlining the declarations. resolves #5  